### PR TITLE
Potential fix for code scanning alert no. 24: Server-side URL redirect

### DIFF
--- a/routes/fileServer.js
+++ b/routes/fileServer.js
@@ -1093,7 +1093,19 @@ router.post('*splat', (req, res, next) => {
   } else if (req.query.action === 'create-folder') {
     const newPath = `${req.path}/folders`;
 
-    if (!isLocalUrl(newPath)) {
+    // Only allow strictly relative paths, no path traversal, not protocol-relative, not external host
+    function isSafeRelativePath(path) {
+      // must start with a single "/"
+      if (typeof path !== 'string' || !path.startsWith('/')) return false;
+      // must not contain "//"
+      if (path.includes('//')) return false;
+      // must not contain ".."
+      if (path.includes('..')) return false;
+      // optional: restrict to allowed base directory/prefix
+      return true;
+    }
+
+    if (!isSafeRelativePath(newPath)) {
       logger.warn('Rejected potentially unsafe redirect', { path: newPath });
       return res.status(400).send('Invalid redirect path');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/STARTcloud/armor/security/code-scanning/24](https://github.com/STARTcloud/armor/security/code-scanning/24)

To reliably fix this issue, we must ensure that redirects based on user-provided values (such as `req.path`) do not allow untrusted or unsafe paths. The best practice is to use a dedicated whitelist of allowed redirect paths or—given the usage context—validate that the destination is both relative and remains within the application, disallowing redirects to external hosts, protocol-relative URLs, or other attacker-controlled URLs.

You should:
- Ensure that `isLocalUrl` only passes "safe" paths (relative paths, not containing things like `..`, not starting with `//` or including external hosts).
- Alternatively, directly validate that the new path is strictly relative and contained within allowed structure (e.g., starting with `/`, not containing any path traversal).
- If a redirect is not allowed due to validation, return an error or redirect to a safe default (such as `/`).

You only need to change the region in `routes/fileServer.js` starting at line 1094 where `newPath` is created from user input and validated. Specifically, improve the validation of `newPath` to ensure it cannot be abused for open redirects by validating against stricter rules. You may also need to implement or update the `isLocalUrl` helper for this purpose, but you can only work with code shown directly in the file.

#### Required changes:
- Update the validation logic for `newPath` (possibly with a stronger local URL check).
- If needed (and if you can see the definition in this file), enhance `isLocalUrl` to strictly check for only relative, non-traversal paths.
- If unsafe, do not redirect and return a safe error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
