### PR TITLE
Potential fix for code scanning alert no. 25: Server-side URL redirect

### DIFF
--- a/routes/fileServer.js
+++ b/routes/fileServer.js
@@ -238,7 +238,12 @@ router.get('*splat', authenticateDownloads, async (req, res) => {
           return res.status(400).send('Invalid redirect path');
         }
 
-        return res.redirect(301, safeRedirectPath);
+        if (isLocalUrl(safeRedirectPath)) {
+          return res.redirect(301, safeRedirectPath);
+        } else {
+          logger.warn('Blocked attempted open redirect', { path: safeRedirectPath });
+          return res.status(400).send('Invalid redirect path');
+        }
       }
       return handleDirectoryListing(req, res, fullPath, requestPath);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/STARTcloud/armor/security/code-scanning/25](https://github.com/STARTcloud/armor/security/code-scanning/25)

To fix this server-side redirect issue, we should ensure that any user-provided path used in a redirect cannot result in a navigation outside the intended application domain/root. The best way to achieve this here is to use a robust validator, preferably encapsulated in a function (such as `isLocalUrl`), to ensure that the redirect is strictly local—i.e., it must remain on the same host and not encode an absolute URL or start with protocol-relative forms. 

In this specific case in `routes/fileServer.js`, before using `safeRedirectPath` as a redirect target (on line 241), we should call `isLocalUrl(safeRedirectPath)` (the function imported from `../config/paths.js`). If `isLocalUrl` returns true, perform the redirect; else, refuse (e.g., by responding with an error or redirecting to '/'). This is a minimal change that does not alter existing functionality beyond making the redirect secure.

**Changes to make:**
- Wrap the redirect in a check: `if (isLocalUrl(safeRedirectPath)) ... else ...`
- If invalid, respond with a 400 or redirect to '/'.
- No new imports are needed, since `isLocalUrl` is already imported.
- Only lines in the 227–241 range are changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
