### PR TITLE
Potential fix for code scanning alert no. 26: Server-side URL redirect

### DIFF
--- a/routes/fileServer.js
+++ b/routes/fileServer.js
@@ -1095,10 +1095,21 @@ router.post('*splat', (req, res, next) => {
       res.status(200).send('Authenticated');
     });
   } else if (req.query.action === 'create-folder') {
-    const newPath = `${req.path}/folders`;
+    // Build newPath and further sanitize
+    let newPath = `${req.path}/folders`;
 
-    // Ensure the redirect is only to a local path and not to an external or dangerous location
-    if (!isLocalUrl(newPath)) {
+    // Normalize the path to prevent directory traversal, double slashes, etc.
+    // Guarantee it starts with a single "/", no "//", no "..", and is not a full URL
+    newPath = newPath.replace(/\/{2,}/g, '/');
+
+    if (
+      typeof newPath !== 'string' ||
+      !newPath.startsWith('/') ||
+      newPath.includes('..') ||
+      newPath.includes('//') ||
+      /https?:\/\//i.test(newPath) ||
+      !isLocalUrl(newPath)
+    ) {
       logger.warn('Rejected potentially unsafe redirect', { path: newPath });
       return res.status(400).send('Invalid redirect path');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/STARTcloud/armor/security/code-scanning/26](https://github.com/STARTcloud/armor/security/code-scanning/26)

The best fix is to further sanitize and validate `newPath` before redirecting. Although `isLocalUrl(newPath)` adds a layer of protection, it's best practice to additionally ensure the constructed `newPath`:

1. Always starts with a single `/`.
2. Does not contain `..`, `//`, or any potentially dangerous or confusing path segments.
3. Is decoded safely (to guard against encoded tricks).
4. Is strictly a local path—never a full URL.

To do this, add checks for:
- Stripping construction of any double slashes.
- Ensuring the path does not have suspicious patterns.
- Optionally, use a safe path normalization function to collapse the path and prevent directory traversal.

Additional step: If `isLocalUrl` isn't sufficient, reimplement or supplement with path normalization and strict checks.

We will update the conditional at lines 1100-1106 to include the new checks described above before allowing the redirect. No new imports are needed, as standard `path` utilities and regular expressions will suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
