### PR TITLE
Potential fix for code scanning alert no. 5: Server-side URL redirect

### DIFF
--- a/routes/fileServer.js
+++ b/routes/fileServer.js
@@ -1110,7 +1110,7 @@ router.post('*splat', (req, res, next) => {
     const newPath = `${safePath}/search`;
 
     // Additional validation to ensure path is safe for internal redirect
-    if (!newPath.startsWith('/') || newPath.includes('..') || newPath.includes('//')) {
+    if (!isLocalUrl(newPath)) {
       logger.warn('Rejected potentially unsafe redirect', { path: newPath });
       return res.status(400).send('Invalid redirect path');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/STARTcloud/armor/security/code-scanning/5](https://github.com/STARTcloud/armor/security/code-scanning/5)

To fix the problem, we must ensure that the resulting redirect path constructed from user input is guaranteed to be both local and safe, and does not allow any untrusted value to trigger an unsafe redirect. The best approach is to validate the `newPath` using the well-established `isLocalUrl()` utility (as occurs in the legacy folder creation redirect above) and ensure proper normalization/encoding. We should replace the existing substring checks and regex sanitization with a call to `isLocalUrl(newPath)` (a utility already imported and likely robust), rejecting any path that fails this validation. This change should be applied around line 1113, replacing the ad-hoc checks with a secure validation. No new methods or dependencies are required, as the utility is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
